### PR TITLE
docs: Remove alternative to docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ flutter build web
 # Go to the root of the repository
 cd ..
 # Build docker image
-# There is an issue with this build command, please follow the instructions on this issue as a workaround :
-# https://github.com/lenra-io/dev-tools/issues/121#issuecomment-1160379764
 docker build -t lenra/devtools:local .
 ```
 


### PR DESCRIPTION
The repositories used by devtools are now public, we can remove this alternative in the docs.


<!-- 
Link the related issue :
#42
-->
#__ 

## Checklist
- [ ] I didn't over-scope my PR
- [ ] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I did not include breaking changes
- [ ] I included unit tests that cover my changes
- [ ] I added/updated the documentation about my changes
- [ ] I made my own code-review before requesting one

## Description of the changes
<!-- 
    Simple description of what changed ?
    This helps the reviewer to understand what happens in your code changes and why.
-->

## Technical highlight/advice
<!-- 
    Is there any complex point you want to highlight ?
    Do you need advice on specific point of your code ?
    Tell us here.
-->
